### PR TITLE
add go-cqhttp service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/go-cqhttp-data

--- a/cqhttp/Dockerfile
+++ b/cqhttp/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:latest
+LABEL maintainer="iskyzh@gmail.com"
 
 WORKDIR /app
 RUN apt-get update -y -qq && apt-get install wget -qq

--- a/cqhttp/Dockerfile
+++ b/cqhttp/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:latest
+
+WORKDIR /app
+RUN apt-get update -y -qq && apt-get install wget -qq
+RUN wget https://github.com/Mrs4s/go-cqhttp/releases/download/v0.9.18/go-cqhttp-v0.9.18-linux-amd64.tar.gz && tar -xvf go-cqhttp-v0.9.18-linux-amd64.tar.gz && rm go-cqhttp-v0.9.18-linux-amd64.tar.gz
+COPY run.sh /app
+CMD /app/run.sh

--- a/cqhttp/run.sh
+++ b/cqhttp/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+cd /go-cqhttp-data
+/app/go-cqhttp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 version: "3"
 services:
-
+  go-cqhttp:
+    build: ./cqhttp
+    image: sjtu-plus/go-cqhttp:1.0
+    volumes:
+      - "./go-cqhttp-data:/go-cqhttp-data"
   cqhttp:
     image: richardchien/cqhttp:latest
     volumes:


### PR DESCRIPTION
`go-cqhttp` will save all temporary file under "go-cqhttp-data" folder. This folder is now ignored in git.